### PR TITLE
feat: add healthcheck for failed master nodes and refactor retry strategy

### DIFF
--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -31,25 +31,19 @@ local DEFAULT_SEND_TIMEOUT = 1000
 local DEFAULT_READ_TIMEOUT = 1000
 local DEFAULT_HEALTH_DICT_NAME = "redis_cluster_health"
 local inspect = require("inspect")
-local function health_check_timer(premature)
-    if premature then return end
+
+local function health_check_timer()
     local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
-    if not health_dict then
-        ngx.log(ngx.WARN, "HEALTH DICT NOT FOUND>RETURNING")
-        return
-    end
     local all_keys = health_dict:get_keys()
     for _, key in ipairs(all_keys) do
-        ngx.log(ngx.WARN, "got key  ", inspect(key))
         local failures = health_dict:get(key)
-        if failures then
-            ngx.log(ngx.WARN, "got failures  ", inspect(failures))
-            if failures <= 3 then
-                health_dict:incr(key, 1)
-                health_dict:expire(key, 5)
-            else
-                health_dict:expire(key, 5)
-            end
+        if failures > 3 then
+            -- Keep unhealthy nodes alive
+            health_dict:incr(key, 1)
+            health_dict:expire(key, 5)
+        else
+            -- Delete healthy nodes
+            health_dict:delete(key)
         end
     end
 end

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -62,14 +62,8 @@ local function health_check_timer(premature)
 
         if ok then
             -- Node is healthy: decrement failure count
-            local current = health_dict:get(key) or 0
-            if current > 0 then
-                health_dict:set(key, current - 1, 60)
-                ngx.log(ngx.WARN, "Node ", key, " is healthy, failures decremented to ", current - 1)
-            else
-                health_dict:delete(key)
-                ngx.log(ngx.WARN, "Node ", key, " is healthy, failures reset")
-            end
+            health_dict:delete(key)
+            ngx.log(ngx.WARN, "Node ", key, " is healthy, failures reset")
         else
             -- Node is unhealthy: increment failures
             local failures = health_dict:get(key) or 0

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -1,3 +1,4 @@
+
 local redis = require "resty.redis"
 local resty_lock = require "resty.lock"
 local xmodem = require "resty.xmodem"
@@ -22,12 +23,36 @@ local redis_crc = xmodem.redis_crc
 local DEFAULT_SHARED_DICT_NAME = "redis_cluster_slot_locks"
 local DEFAULT_REFRESH_DICT_NAME = "refresh_lock"
 local DEFAULT_MAX_REDIRECTION = 5
-local DEFAULT_MAX_CONNECTION_ATTEMPTS = 3
+local DEFAULT_MAX_CONNECTION_ATTEMPTS = 2
 local DEFAULT_KEEPALIVE_TIMEOUT = 55000
 local DEFAULT_KEEPALIVE_CONS = 1000
 local DEFAULT_CONNECTION_TIMEOUT = 1000
 local DEFAULT_SEND_TIMEOUT = 1000
 local DEFAULT_READ_TIMEOUT = 1000
+local DEFAULT_HEALTH_DICT_NAME = "redis_cluster_health"
+
+local function health_check_timer(premature)
+    if premature then return end
+    local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
+    if not health_dict then
+        return
+    end
+
+    local all_keys = health_dict:get_keys()
+    for _, key in ipairs(all_keys) do
+        local failures = health_dict:get(key)
+        if failures then
+            if failures <= 3 then
+                health_dict:incr(key, 1)
+                health_dict:expire(key, 5)
+            else
+                health_dict:expire(key, 5)
+            end
+        end
+    end
+end
+
+ngx.timer.every(1, health_check_timer)
 
 local function parse_key(key_str)
     local left_tag_single_index = string_find(key_str, "{", 0)
@@ -47,6 +72,30 @@ local mt = { __index = _M }
 
 local slot_cache = {}
 local master_nodes = {}
+
+local function track_node_failure(ip, port)
+    local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
+    if not health_dict then
+        return
+    end
+
+    local key = ip .. ":" .. port
+    local newval, err = health_dict:incr(key, 1, 0, 5)
+    if not newval then
+        health_dict:set(key, 1, 5)
+    end
+end
+
+local function is_node_healthy(ip, port)
+    local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
+    if not health_dict then
+        return true
+    end
+
+    local key = ip .. ":" .. port
+    return (health_dict:get(key) or 0) <= 3
+end
+
 
 local cmds_for_all_master = {
     ["flushall"] = true,
@@ -108,14 +157,19 @@ local function try_hosts_slots(self, serv_list)
     for i = 1, #serv_list do
         local ip = serv_list[i].ip
         local port = serv_list[i].port
+
+        if not is_node_healthy(ip, port) then
+            ngx.log(ngx.WARN, "skipping unhealthy node ", ip, ":", port)
+            goto continue
+        end
         local redis_client = redis:new()
         local ok, err, max_connection_timeout_err
-        redis_client:set_timeouts(config.connect_timeout or DEFAULT_CONNECTION_TIMEOUT,
-                                  config.send_timeout or DEFAULT_SEND_TIMEOUT,
-                                  config.read_timeout or DEFAULT_READ_TIMEOUT)
-
         --attempt to connect DEFAULT_MAX_CONNECTION_ATTEMPTS times to redis
         for k = 1, config.max_connection_attempts or DEFAULT_MAX_CONNECTION_ATTEMPTS do
+            local attempt_timeout = k == 1 and 100 or 800  -- 100ms first attempt, 800ms retry
+            redis_client:set_timeouts(attempt_timeout,
+            config.send_timeout or DEFAULT_SEND_TIMEOUT,
+            config.read_timeout or DEFAULT_READ_TIMEOUT)
             local total_connection_time_ms = (ngx.now() - start_time) * 1000
             if (config.max_connection_timeout and total_connection_time_ms > config.max_connection_timeout) then
                 max_connection_timeout_err = "max_connection_timeout of " .. config.max_connection_timeout .. "ms reached."
@@ -202,6 +256,7 @@ local function try_hosts_slots(self, serv_list)
         else
             table_insert(errors, err)
         end
+        ::continue::
         if #errors == 0 then
             return true, nil
         end
@@ -257,6 +312,23 @@ function _M.refresh_slots(self)
     end
 
     self:fetch_slots()
+    -- Cleanup health dict entries for removed nodes
+    local current_nodes = {}
+    local servers = slot_cache[self.config.name .. "serv_list"].serv_list
+    for _, node in ipairs(servers) do
+        current_nodes[node.ip .. ":" .. node.port] = true
+    end
+
+    local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
+    if health_dict then
+        local all_keys = health_dict:get_keys()
+        for _, key in ipairs(all_keys) do
+            if not current_nodes[key] then
+                health_dict:delete(key)
+            end
+        end
+    end
+
     ok, err = lock:unlock()
     if not ok then
         ngx.log(ngx.ERR, "failed to unlock in refresh slot cache:", err)
@@ -330,33 +402,44 @@ end
 
 
 local function pick_node(self, serv_list, slot, magic_radom_seed)
+    local healthy_servers = {}
+    for _, node in ipairs(serv_list) do
+        if is_node_healthy(node.ip, node.port) then
+            table_insert(healthy_servers, node)
+        end
+    end
+
+    if #healthy_servers == 0 then
+        ngx.log(ngx.WARN, "All nodes for slot ", slot, " are unhealthy, using original list")
+        healthy_servers = serv_list
+    end
     local host
     local port
     local slave
     local index
-    if #serv_list < 1 then
+    if #healthy_servers < 1 then
         return nil, nil, nil, "serv_list for slot " .. slot .. " is empty"
     end
     if self.config.enable_slave_read then
         if magic_radom_seed then
-            index = magic_radom_seed % #serv_list + 1
+            index = magic_radom_seed % #healthy_servers + 1
         else
-            index = math.random(#serv_list)
+            index = math.random(#healthy_servers)
         end
-        host = serv_list[index].ip
-        port = serv_list[index].port
+        host = healthy_servers[index].ip
+        port = healthy_servers[index].port
         --cluster slots will always put the master node as first
         if index > 1 then
             slave = true
         else
             slave = false
         end
-        --ngx.log(ngx.NOTICE, "pickup node: ", c(serv_list[index]))
+        --ngx.log(ngx.NOTICE, "pickup node: ", c(healthy_servers[index]))
     else
-        host = serv_list[1].ip
-        port = serv_list[1].port
+        host = healthy_servers[1].ip
+        port = healthy_servers[1].port
         slave = false
-        --ngx.log(ngx.NOTICE, "pickup node: ", cjson.encode(serv_list[1]))
+        --ngx.log(ngx.NOTICE, "pickup node: ", cjson.encode(healthy_servers[1]))
     end
     return host, port, slave
 end
@@ -416,7 +499,7 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
     local slot = redis_slot(key)
 
     for k = 1, config.max_redirection or DEFAULT_MAX_REDIRECTION do
-
+        local attempt_timeout = k == 1 and 100 or 800  -- 100ms first attempt, 800ms retry
         if k > 1 then
             ngx.log(ngx.NOTICE, "handle retry attempts:" .. k .. " for cmd:" .. cmd .. " key:" .. key)
         end
@@ -446,11 +529,13 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
         end
 
         local redis_client = redis:new()
-        redis_client:set_timeouts(config.connect_timeout or DEFAULT_CONNECTION_TIMEOUT,
+        redis_client:set_timeouts(attempt_timeout,
                                   config.send_timeout or DEFAULT_SEND_TIMEOUT,
                                   config.read_timeout or DEFAULT_READ_TIMEOUT)
         local ok, connerr = redis_client:connect(ip, port, self.config.connect_opts)
-
+        if not ok then
+            track_node_failure(ip, port)
+        end
         if ok then
             local authok, autherr = check_auth(self, redis_client)
             if autherr then

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -85,8 +85,6 @@ local function health_check_timer(premature)
     end
 end
 
-ngx.timer.every(1, health_check_timer)
-
 local function track_node_failure(ip, port, name)
     local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
     if not health_dict then
@@ -921,5 +919,9 @@ setmetatable(_M, {
         return method
     end
 })
+
+function _M.init()
+    ngx.timer.every(1, health_check_timer)
+end
 
 return _M

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -256,10 +256,10 @@ local function try_hosts_slots(self, serv_list)
         else
             table_insert(errors, err)
         end
-        ::continue::
         if #errors == 0 then
             return true, nil
         end
+        ::continue::
     end
     return nil, errors
 end

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -22,7 +22,7 @@ local redis_crc = xmodem.redis_crc
 
 local DEFAULT_SHARED_DICT_NAME = "redis_cluster_slot_locks"
 local DEFAULT_REFRESH_DICT_NAME = "refresh_lock"
-local DEFAULT_MAX_REDIRECTION = 5
+local DEFAULT_MAX_REDIRECTION = 2
 local DEFAULT_MAX_CONNECTION_ATTEMPTS = 2
 local DEFAULT_KEEPALIVE_TIMEOUT = 55000
 local DEFAULT_KEEPALIVE_CONS = 1000
@@ -48,6 +48,7 @@ local function health_check_timer(premature)
                 health_dict:incr(key, 1)
                 health_dict:expire(key, 5)
             else
+                health_dict:set(key, 0, 5)
                 health_dict:expire(key, 5)
             end
         end
@@ -417,8 +418,7 @@ local function pick_node(self, serv_list, slot, magic_radom_seed)
     end
 
     if #healthy_servers == 0 then
-        ngx.log(ngx.WARN, "All nodes for slot ", slot, " are unhealthy, using original list")
-        healthy_servers = serv_list
+        return nil, "No healthy nodes"
     end
     local host
     local port

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -48,7 +48,6 @@ local function health_check_timer(premature)
                 health_dict:incr(key, 1)
                 health_dict:expire(key, 5)
             else
-                health_dict:set(key, 0, 5)
                 health_dict:expire(key, 5)
             end
         end
@@ -154,6 +153,7 @@ local function split(s, delimiter)
 end
 
 local function try_hosts_slots(self, serv_list)
+    ngx.log(ngx.WARN, "HOST SLOT CALLED ---- ")
     local start_time = ngx.now()
     local errors = {}
     local config = self.config
@@ -165,10 +165,13 @@ local function try_hosts_slots(self, serv_list)
         local ip = serv_list[i].ip
         local port = serv_list[i].port
         ngx.log(ngx.WARN, "trying to connect to ", ip, ":", port)
-        if not is_node_healthy(ip, port) then
+        local is_healthy = is_node_healthy(ip, port)
+        ngx.log(ngx.WARN, "is_healthy called in try_host_slots: ", is_healthy)
+        if not is_healthy then
             ngx.log(ngx.WARN, "skipping unhealthy node ", ip, ":", port)
             goto continue
         end
+        ngx.log(ngx.WARN, "HEALTHY NODE. WILL TRY TO CONNECT ---- ")
         local redis_client = redis:new()
         local ok, err, max_connection_timeout_err
         --attempt to connect DEFAULT_MAX_CONNECTION_ATTEMPTS times to redis
@@ -186,15 +189,21 @@ local function try_hosts_slots(self, serv_list)
             end
 
             ok, err = redis_client:connect(ip, port, self.config.connect_opts)
-            if ok then break end
+
+            if ok then 
+                ngx.log(ngx.WARN, "CONNECTED JUST FINE ")
+                break 
+            end
             if err then
+                ngx.log(ngx.WARN, "DID NOT CONNECT WILL CALL TRACK NODE FAILURE. ---- ")
                 track_node_failure(ip, port)
                 ngx.log(ngx.ERR,"unable to connect, attempt nr ", k, " : error: ", err)
                 table_insert(errors, err)
             end
         end
-
+        ngx.log(ngx.WARN, "ALL ATTEMPTS OVER")
         if ok then
+            ngx.log(ngx.WARN, "OKAY ---- ")
             local _, autherr = check_auth(self, redis_client)
             if autherr then
                 table_insert(errors, autherr)
@@ -260,11 +269,13 @@ local function try_hosts_slots(self, serv_list)
                 return true, nil
             end
         elseif max_connection_timeout_err then
+            ngx.log(ngx.WARN, "MAXX CONN TIMEOUT ---- ")
             break
         else
             table_insert(errors, err)
         end
         if #errors == 0 then
+            ngx.log(ngx.WARN, "RETURNING ")
             return true, nil
         end
         ::continue::
@@ -412,7 +423,10 @@ end
 local function pick_node(self, serv_list, slot, magic_radom_seed)
     local healthy_servers = {}
     for _, node in ipairs(serv_list) do
-        if is_node_healthy(node.ip, node.port) then
+        local is_healthy = is_node_healthy(node.ip, node.port)
+        ngx.log(ngx.WARN, "is_node_healthy called in pick_node: ", is_healthy)
+        if is_healthy then
+            ngx.log(ngx.WARN, "healthy node: ", node.ip, ":", node.port)
             table_insert(healthy_servers, node)
         end
     end
@@ -420,6 +434,7 @@ local function pick_node(self, serv_list, slot, magic_radom_seed)
     if #healthy_servers == 0 then
         return nil, "No healthy nodes"
     end
+    ngx.log(ngx.WARN, "healthy servers: ", inspect(healthy_servers))
     local host
     local port
     local slave

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -48,7 +48,7 @@ local function health_check_timer(premature)
             goto continue
         end
         port = tonumber(port)
-
+        local ok
         -- Create a new Redis client for each check
         local red = redis:new()
         red:set_timeouts(500, 500, 500)  -- 500ms for connect/send/read
@@ -65,7 +65,6 @@ local function health_check_timer(premature)
             ngx.log(ngx.WARN, "Health check for node ", key, ": ", res, " err: ", err)
             red:close()  -- Close connection after check
         end
-
         -- Update health status based on check
         if ok then
             health_dict:set(key, 0, 0)  -- Healthy: reset failures, no TTL
@@ -357,10 +356,6 @@ function _M.refresh_slots(self)
     for _, node in ipairs(servers) do
         local key = node.ip .. ":" .. node.port
         current_nodes[key] = true
-        -- Add node to health_dict if missing, with no TTL
-        if not health_dict:get(key) then
-            health_dict:set(key, 0, 0)  -- TTL=0 (persistent)
-        end
     end
     -- Cleanup stale nodes
     local all_keys = health_dict:get_keys()
@@ -571,6 +566,9 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
         else
             ip, port, slave, err = pick_node(self, serv_list, slot)
             if err then
+                if err == err_unhealthy_master then
+                    return nil, err
+                end
                 ngx.log(ngx.ERR, "pickup node failed, will return failed for this request, meanwhile refereshing slotcache " .. err)
                 self:refresh_slots()
                 return nil, err

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -30,18 +30,20 @@ local DEFAULT_CONNECTION_TIMEOUT = 1000
 local DEFAULT_SEND_TIMEOUT = 1000
 local DEFAULT_READ_TIMEOUT = 1000
 local DEFAULT_HEALTH_DICT_NAME = "redis_cluster_health"
-
+local inspect = require("inspect")
 local function health_check_timer(premature)
     if premature then return end
     local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
     if not health_dict then
+        ngx.log(ngx.WARN, "HEALTH DICT NOT FOUND>RETURNING")
         return
     end
-
     local all_keys = health_dict:get_keys()
     for _, key in ipairs(all_keys) do
+        ngx.log(ngx.WARN, "got key  ", inspect(key))
         local failures = health_dict:get(key)
         if failures then
+            ngx.log(ngx.WARN, "got failures  ", inspect(failures))
             if failures <= 3 then
                 health_dict:incr(key, 1)
                 health_dict:expire(key, 5)
@@ -74,6 +76,7 @@ local slot_cache = {}
 local master_nodes = {}
 
 local function track_node_failure(ip, port)
+    ngx.log(ngx.WARN, "called track_node_failure")
     local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
     if not health_dict then
         return
@@ -87,13 +90,16 @@ local function track_node_failure(ip, port)
 end
 
 local function is_node_healthy(ip, port)
+    ngx.log(ngx.WARN, "called is_node_healthy")
     local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
     if not health_dict then
         return true
     end
 
     local key = ip .. ":" .. port
-    return (health_dict:get(key) or 0) <= 3
+    local is_healthy = (health_dict:get(key) or 0) <= 3
+    ngx.log(ngx.WARN, "is_node_healthy: ", key, " is_healthy: ", is_healthy)
+    return is_healthy
 end
 
 
@@ -153,11 +159,11 @@ local function try_hosts_slots(self, serv_list)
     if #serv_list < 1 then
         return nil, "failed to fetch slots, serv_list config is empty"
     end
-
+    ngx.log(ngx.WARN, "serv_list is ", inspect(serv_list))
     for i = 1, #serv_list do
         local ip = serv_list[i].ip
         local port = serv_list[i].port
-
+        ngx.log(ngx.WARN, "trying to connect to ", ip, ":", port)
         if not is_node_healthy(ip, port) then
             ngx.log(ngx.WARN, "skipping unhealthy node ", ip, ":", port)
             goto continue
@@ -181,6 +187,7 @@ local function try_hosts_slots(self, serv_list)
             ok, err = redis_client:connect(ip, port, self.config.connect_opts)
             if ok then break end
             if err then
+                track_node_failure(ip, port)
                 ngx.log(ngx.ERR,"unable to connect, attempt nr ", k, " : error: ", err)
                 table_insert(errors, err)
             end

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -40,6 +40,7 @@ local function health_check_timer(premature)
 
     local all_keys = health_dict:get_keys()
     ngx.log(ngx.WARN, "Health check for keys: ", inspect(all_keys))
+
     for _, key in ipairs(all_keys) do
         local ip, port = string.match(key, "^(.-):(%d+)$")
         if not ip or not port then
@@ -47,15 +48,31 @@ local function health_check_timer(premature)
             goto continue
         end
         port = tonumber(port)
-        -- Perform health check...
+
+        -- Create a new Redis client for each check
+        local red = redis:new()
+        red:set_timeouts(500, 500, 500)  -- 500ms for connect/send/read
+
+        -- Attempt to connect and send PING
+        local ok, err = red:connect(ip, port)
         if ok then
-            -- Node is healthy: reset failures to 0 but KEEP the entry
-            health_dict:set(key, 0, 60)  -- Reset failures, TTL 60s
+            -- Check if PING succeeds
+            local res, err = red:ping()
+            if res == nil then
+                ok = false
+                err = "PING failed"
+            end
+            ngx.log(ngx.WARN, "Health check for node ", key, ": ", res, " err: ", err)
+            red:close()  -- Close connection after check
+        end
+
+        -- Update health status based on check
+        if ok then
+            health_dict:set(key, 0, 0)  -- Healthy: reset failures, no TTL
             ngx.log(ngx.WARN, "Node ", key, " is healthy (failures=0)")
         else
-            -- Node is unhealthy: increment failures
             local failures = health_dict:get(key) or 0
-            health_dict:set(key, failures + 1, 60)
+            health_dict:set(key, failures + 1, 60)  -- Unhealthy: increment failures with TTL
             ngx.log(ngx.WARN, "Node ", key, " is unhealthy (failures=", failures + 1, ")")
         end
 

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -31,20 +31,53 @@ local DEFAULT_SEND_TIMEOUT = 1000
 local DEFAULT_READ_TIMEOUT = 1000
 local DEFAULT_HEALTH_DICT_NAME = "redis_cluster_health"
 local inspect = require("inspect")
+local err_unhealthy_master = "master node is unhealthy"
+local function health_check_timer(premature)
+    if premature then return end
 
-local function health_check_timer()
     local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
+    if not health_dict then return end
+
     local all_keys = health_dict:get_keys()
+    ngx.log(ngx.WARN, "TIMER CALLED WITH KEYS ", inspect(all_keys))
     for _, key in ipairs(all_keys) do
-        local failures = health_dict:get(key)
-        if failures > 3 then
-            -- Keep unhealthy nodes alive
-            health_dict:incr(key, 1)
-            health_dict:expire(key, 5)
-        else
-            -- Delete healthy nodes
+        local ip, port = string.match(key, "^(.-):(%d+)$")
+        if not ip or not port then
             health_dict:delete(key)
+            goto continue
         end
+        port = tonumber(port)
+
+        local redis_client = redis:new()
+        redis_client:set_timeouts(500, 500, 500)
+        local ok, err = redis_client:connect(ip, port)
+        if ok then
+            local res, err = redis_client:ping()
+            if res == ngx.null then
+                ok = false
+                err = "PING failed"
+            end
+            redis_client:close()
+        end
+
+        if ok then
+            -- Node is healthy: decrement failure count
+            local current = health_dict:get(key) or 0
+            if current > 0 then
+                health_dict:set(key, current - 1, 60)
+                ngx.log(ngx.WARN, "Node ", key, " is healthy, failures decremented to ", current - 1)
+            else
+                health_dict:delete(key)
+                ngx.log(ngx.WARN, "Node ", key, " is healthy, failures reset")
+            end
+        else
+            -- Node is unhealthy: increment failures
+            local failures = health_dict:get(key) or 0
+            health_dict:set(key, failures + 1, 60)
+            ngx.log(ngx.WARN, "Node ", key, " is unhealthy (failures=", failures + 1, ")")
+        end
+
+        ::continue::
     end
 end
 
@@ -70,21 +103,20 @@ local slot_cache = {}
 local master_nodes = {}
 
 local function track_node_failure(ip, port)
-    ngx.log(ngx.WARN, "called track_node_failure")
+    ngx.log(ngx.WARN, "track node failure for ip:", ip, " port:", port)
     local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
     if not health_dict then
         return
     end
 
     local key = ip .. ":" .. port
-    local newval, err = health_dict:incr(key, 1, 0, 5)
+    local newval, err = health_dict:incr(key, 1, 0, 60)
     if not newval then
-        health_dict:set(key, 1, 5)
+        health_dict:set(key, 1, 60)
     end
 end
 
 local function is_node_healthy(ip, port)
-    ngx.log(ngx.WARN, "called is_node_healthy")
     local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
     if not health_dict then
         return true
@@ -92,7 +124,10 @@ local function is_node_healthy(ip, port)
 
     local key = ip .. ":" .. port
     local is_healthy = (health_dict:get(key) or 0) <= 3
-    ngx.log(ngx.WARN, "is_node_healthy: ", key, " is_healthy: ", is_healthy)
+    if not is_healthy then
+        ngx.log(ngx.WARN, "node is unhealthy, ip:", ip, " port:", port)
+        ngx.log(ngx.WARN, "node failure count:", health_dict:get(key))
+    end
     return is_healthy
 end
 
@@ -147,25 +182,19 @@ local function split(s, delimiter)
 end
 
 local function try_hosts_slots(self, serv_list)
-    ngx.log(ngx.WARN, "HOST SLOT CALLED ---- ")
     local start_time = ngx.now()
     local errors = {}
     local config = self.config
     if #serv_list < 1 then
         return nil, "failed to fetch slots, serv_list config is empty"
     end
-    ngx.log(ngx.WARN, "serv_list is ", inspect(serv_list))
     for i = 1, #serv_list do
         local ip = serv_list[i].ip
         local port = serv_list[i].port
-        ngx.log(ngx.WARN, "trying to connect to ", ip, ":", port)
         local is_healthy = is_node_healthy(ip, port)
-        ngx.log(ngx.WARN, "is_healthy called in try_host_slots: ", is_healthy)
         if not is_healthy then
-            ngx.log(ngx.WARN, "skipping unhealthy node ", ip, ":", port)
             goto continue
         end
-        ngx.log(ngx.WARN, "HEALTHY NODE. WILL TRY TO CONNECT ---- ")
         local redis_client = redis:new()
         local ok, err, max_connection_timeout_err
         --attempt to connect DEFAULT_MAX_CONNECTION_ATTEMPTS times to redis
@@ -185,19 +214,14 @@ local function try_hosts_slots(self, serv_list)
             ok, err = redis_client:connect(ip, port, self.config.connect_opts)
 
             if ok then 
-                ngx.log(ngx.WARN, "CONNECTED JUST FINE ")
                 break 
             end
             if err then
-                ngx.log(ngx.WARN, "DID NOT CONNECT WILL CALL TRACK NODE FAILURE. ---- ")
                 track_node_failure(ip, port)
-                ngx.log(ngx.ERR,"unable to connect, attempt nr ", k, " : error: ", err)
                 table_insert(errors, err)
             end
         end
-        ngx.log(ngx.WARN, "ALL ATTEMPTS OVER")
         if ok then
-            ngx.log(ngx.WARN, "OKAY ---- ")
             local _, autherr = check_auth(self, redis_client)
             if autherr then
                 table_insert(errors, autherr)
@@ -263,13 +287,11 @@ local function try_hosts_slots(self, serv_list)
                 return true, nil
             end
         elseif max_connection_timeout_err then
-            ngx.log(ngx.WARN, "MAXX CONN TIMEOUT ---- ")
             break
         else
             table_insert(errors, err)
         end
         if #errors == 0 then
-            ngx.log(ngx.WARN, "RETURNING ")
             return true, nil
         end
         ::continue::
@@ -326,19 +348,24 @@ function _M.refresh_slots(self)
 
     self:fetch_slots()
     -- Cleanup health dict entries for removed nodes
+    local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
     local current_nodes = {}
     local servers = slot_cache[self.config.name .. "serv_list"].serv_list
+    ngx.log(ngx.WARN, "WILL ITERATE OVER SERVERS ", inspect(servers))
     for _, node in ipairs(servers) do
-        current_nodes[node.ip .. ":" .. node.port] = true
+        local key = node.ip .. ":" .. node.port
+        current_nodes[key] = true
+        -- Initialize node with 0 failures if not present
+        if not health_dict:get(key) then
+            health_dict:set(key, 0, 60)  -- TTL 60 seconds
+        end
     end
 
-    local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
-    if health_dict then
-        local all_keys = health_dict:get_keys()
-        for _, key in ipairs(all_keys) do
-            if not current_nodes[key] then
-                health_dict:delete(key)
-            end
+    -- Cleanup stale nodes
+    local all_keys = health_dict:get_keys()
+    for _, key in ipairs(all_keys) do
+        if not current_nodes[key] then
+            health_dict:delete(key)
         end
     end
 
@@ -416,19 +443,20 @@ end
 
 local function pick_node(self, serv_list, slot, magic_radom_seed)
     local healthy_servers = {}
-    for _, node in ipairs(serv_list) do
+    for i, node in ipairs(serv_list) do
+        -- first node here is master. If its unhealthy then we should return err
         local is_healthy = is_node_healthy(node.ip, node.port)
-        ngx.log(ngx.WARN, "is_node_healthy called in pick_node: ", is_healthy)
+        if i == 1 and not is_healthy then
+            return nil, nil, nil, err_unhealthy_master
+        end
         if is_healthy then
-            ngx.log(ngx.WARN, "healthy node: ", node.ip, ":", node.port)
             table_insert(healthy_servers, node)
         end
     end
-
-    if #healthy_servers == 0 then
-        return nil, "No healthy nodes"
-    end
     ngx.log(ngx.WARN, "healthy servers: ", inspect(healthy_servers))
+    if #healthy_servers == 0 then
+        return nil, nil, nil, "No healthy nodes"
+    end
     local host
     local port
     local slave
@@ -489,6 +517,15 @@ local function parse_ask_signal(res)
     return nil, nil
 end
 
+local function parse_moved_signal(err)
+    -- MOVED error format: "MOVED <slot> <host>:<port>"
+    local host, port = string.match(err, "^MOVED %d+ ([%d%.]+):(%d+)$")
+    if not host then
+        -- Fallback pattern for non-IP hostnames
+        host, port = string.match(err, "^MOVED %d+ ([^:]+):(%d+)$")
+    end
+    return host, tonumber(port)
+end
 
 local function has_moved_signal(res)
     if res ~= ngx.null then
@@ -513,11 +550,12 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
 
     key = tostring(key)
     local slot = redis_slot(key)
-
+    ngx.log(ngx.WARN, "HANDLE COMMAND CALLED WITH TARGET IP AND PORT", target_ip, " ", target_port)
     for k = 1, config.max_redirection or DEFAULT_MAX_REDIRECTION do
+        ngx.log(ngx.WARN, "handle retry attempts:" , k )
         local attempt_timeout = k == 1 and 100 or 800  -- 100ms first attempt, 800ms retry
         if k > 1 then
-            ngx.log(ngx.NOTICE, "handle retry attempts:" .. k .. " for cmd:" .. cmd .. " key:" .. key)
+            ngx.log(ngx.WARN, "handle retry attempts:" .. k .. " for cmd:" .. cmd .. " key:" .. key)
         end
 
         local slots = slot_cache[self.config.name]
@@ -543,12 +581,13 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
                 return nil, err
             end
         end
-
+        ngx.log(ngx.WARN, "handle command with ip and port", ip, " ", port)
         local redis_client = redis:new()
         redis_client:set_timeouts(attempt_timeout,
                                   config.send_timeout or DEFAULT_SEND_TIMEOUT,
                                   config.read_timeout or DEFAULT_READ_TIMEOUT)
         local ok, connerr = redis_client:connect(ip, port, self.config.connect_opts)
+        ngx.log(ngx.WARN, "okay and connerr", ok, " ", connerr)
         if not ok then
             track_node_failure(ip, port)
         end
@@ -582,7 +621,7 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
             else
                 res, err = redis_client[cmd](redis_client, key, ...)
             end
-
+            ngx.log(ngx.WARN, "err returned is ", err)
             if err then
                 if string.sub(err, 1, 5) == "MOVED" then
                     --ngx.log(ngx.NOTICE, "find MOVED signal, trigger retry for normal commands, cmd:" .. cmd .. " key:" .. key)
@@ -613,6 +652,7 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
                     return nil, "Cannot executing command, cluster status is failed!"
                 else
                     --There might be node fail, we should also refresh slot cache
+                    track_node_failure(ip, port)
                     self:refresh_slots()
                     return nil, err
                 end
@@ -622,6 +662,7 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
                 return res, err
             end
         else
+            ngx.log(ngx.ERR, "I WAS HERE")
             --There might be node fail, we should also refresh slot cache
             self:refresh_slots()
             if k == config.max_redirection or k == DEFAULT_MAX_REDIRECTION then
@@ -630,6 +671,7 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
             end
         end
     end
+    ngx.log(ngx.WARN, "WE GOT A PROBLEM")
     return nil, "failed to execute command, reaches maximum redirection attempts"
 end
 

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -39,7 +39,7 @@ local function health_check_timer(premature)
     if not health_dict then return end
 
     local all_keys = health_dict:get_keys()
-    ngx.log(ngx.WARN, "TIMER CALLED WITH KEYS ", inspect(all_keys))
+    ngx.log(ngx.WARN, "Health check for keys: ", inspect(all_keys))
     for _, key in ipairs(all_keys) do
         local ip, port = string.match(key, "^(.-):(%d+)$")
         if not ip or not port then
@@ -47,23 +47,11 @@ local function health_check_timer(premature)
             goto continue
         end
         port = tonumber(port)
-
-        local redis_client = redis:new()
-        redis_client:set_timeouts(500, 500, 500)
-        local ok, err = redis_client:connect(ip, port)
+        -- Perform health check...
         if ok then
-            local res, err = redis_client:ping()
-            if res == ngx.null then
-                ok = false
-                err = "PING failed"
-            end
-            redis_client:close()
-        end
-
-        if ok then
-            -- Node is healthy: decrement failure count
-            health_dict:delete(key)
-            ngx.log(ngx.WARN, "Node ", key, " is healthy, failures reset")
+            -- Node is healthy: reset failures to 0 but KEEP the entry
+            health_dict:set(key, 0, 60)  -- Reset failures, TTL 60s
+            ngx.log(ngx.WARN, "Node ", key, " is healthy (failures=0)")
         else
             -- Node is unhealthy: increment failures
             local failures = health_dict:get(key) or 0
@@ -76,6 +64,22 @@ local function health_check_timer(premature)
 end
 
 ngx.timer.every(1, health_check_timer)
+
+local function track_node_failure(ip, port)
+    ngx.log(ngx.WARN, "track node failure for ip:", ip, " port:", port)
+    local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
+    if not health_dict then
+        return
+    end
+    ngx.log(ngx.WARN, "track node failure for ip: 2", ip, " port:", port)
+    local key = ip .. ":" .. port
+    health_dict:incr(key, 1, 0, 60)
+    -- if not newval then
+    --     health_dict:set(key, 1, 0, 60)
+    -- end
+    local all_keys = health_dict:get_keys()
+    ngx.log(ngx.WARN, "Health check for keys after track node fail: ", inspect(all_keys))
+end
 
 local function parse_key(key_str)
     local left_tag_single_index = string_find(key_str, "{", 0)
@@ -96,19 +100,7 @@ local mt = { __index = _M }
 local slot_cache = {}
 local master_nodes = {}
 
-local function track_node_failure(ip, port)
-    ngx.log(ngx.WARN, "track node failure for ip:", ip, " port:", port)
-    local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
-    if not health_dict then
-        return
-    end
 
-    local key = ip .. ":" .. port
-    local newval, err = health_dict:incr(key, 1, 0, 60)
-    if not newval then
-        health_dict:set(key, 1, 60)
-    end
-end
 
 local function is_node_healthy(ip, port)
     local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
@@ -295,6 +287,7 @@ end
 
 
 function _M.fetch_slots(self)
+    ngx.log(ngx.WARN, "CALLED FETCH SLOT")
     local serv_list = self.config.serv_list
     local serv_list_cached = slot_cache[self.config.name .. "serv_list"]
 
@@ -315,7 +308,6 @@ function _M.fetch_slots(self)
     end
 
     serv_list_cached = nil -- important!
-
     local _, errors = try_hosts_slots(self, serv_list_combined)
     if errors then
         local err = "failed to fetch slots: " .. table.concat(errors, ";")
@@ -345,20 +337,19 @@ function _M.refresh_slots(self)
     local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
     local current_nodes = {}
     local servers = slot_cache[self.config.name .. "serv_list"].serv_list
-    ngx.log(ngx.WARN, "WILL ITERATE OVER SERVERS ", inspect(servers))
     for _, node in ipairs(servers) do
         local key = node.ip .. ":" .. node.port
         current_nodes[key] = true
-        -- Initialize node with 0 failures if not present
+        -- Add node to health_dict if missing, with no TTL
         if not health_dict:get(key) then
-            health_dict:set(key, 0, 60)  -- TTL 60 seconds
+            health_dict:set(key, 0, 0)  -- TTL=0 (persistent)
         end
     end
-
     -- Cleanup stale nodes
     local all_keys = health_dict:get_keys()
     for _, key in ipairs(all_keys) do
         if not current_nodes[key] then
+            ngx.log(ngx.WARN, "Cleaning up stale node: ", key)
             health_dict:delete(key)
         end
     end
@@ -372,6 +363,7 @@ end
 
 
 function _M.init_slots(self)
+    ngx.log(ngx.WARN, "CALLED INIT SLOTS")
     if slot_cache[self.config.name] then
         -- already initialized
         return true
@@ -417,6 +409,7 @@ end
 
 
 function _M.new(_, config)
+    ngx.log(ngx.WARN, "NEW CALLED")
     if not config.name then
         return nil, " redis cluster config name is empty"
     end
@@ -511,15 +504,6 @@ local function parse_ask_signal(res)
     return nil, nil
 end
 
-local function parse_moved_signal(err)
-    -- MOVED error format: "MOVED <slot> <host>:<port>"
-    local host, port = string.match(err, "^MOVED %d+ ([%d%.]+):(%d+)$")
-    if not host then
-        -- Fallback pattern for non-IP hostnames
-        host, port = string.match(err, "^MOVED %d+ ([^:]+):(%d+)$")
-    end
-    return host, tonumber(port)
-end
 
 local function has_moved_signal(res)
     if res ~= ngx.null then

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -37,10 +37,14 @@ end
 
 
 local function health_check_timer(premature)
-    if premature then return end
+    if premature then
+        return
+    end
 
     local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
-    if not health_dict then return end
+    if not health_dict then
+        return
+    end
 
     local all_keys = health_dict:get_keys()
     ngx.log(ngx.WARN, "health check keys: ", inspect(all_keys))
@@ -206,10 +210,11 @@ local function try_hosts_slots(self, serv_list)
 
             ok, err = redis_client:connect(ip, port, self.config.connect_opts)
 
-            if ok then 
-                break 
+            if ok then
+                break
             end
             if err then
+                ngx.log(ngx.ERR,"unable to connect, attempt nr ", k, " : error: ", err)
                 track_node_failure(ip, port, self.config.name)
                 table_insert(errors, err)
             end

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -29,8 +29,13 @@ local DEFAULT_CONNECTION_TIMEOUT = 1000
 local DEFAULT_SEND_TIMEOUT = 1000
 local DEFAULT_READ_TIMEOUT = 1000
 local DEFAULT_HEALTH_DICT_NAME = "redis_cluster_health"
-local inspect = require("inspect")
 local err_unhealthy_master = "master node is unhealthy"
+local inspect = require "inspect"
+local function generate_key(name, ip, port)
+    return name .. ":" .. ip .. ":" .. port
+end
+
+
 local function health_check_timer(premature)
     if premature then return end
 
@@ -38,8 +43,9 @@ local function health_check_timer(premature)
     if not health_dict then return end
 
     local all_keys = health_dict:get_keys()
+    ngx.log(ngx.WARN, "health check keys: ", inspect(all_keys))
     for _, key in ipairs(all_keys) do
-        local ip, port = string.match(key, "^(.-):(%d+)$")
+        local ip, port = string.match(key, "^[^:]+:([^:]+):(%d+)$")
         if not ip or not port then
             health_dict:delete(key)
             goto continue
@@ -49,7 +55,7 @@ local function health_check_timer(premature)
         -- Create a new Redis client for each check
         local red = redis:new()
         red:set_timeouts(500, 500, 500)  -- 500ms for connect/send/read
-
+        ngx.log(ngx.WARN, "health check for: ", ip, ":", port)
         -- Attempt to connect and send PING
         local ok, err = red:connect(ip, port)
         if ok then
@@ -64,9 +70,11 @@ local function health_check_timer(premature)
         -- Update health status based on check
         if ok then
             health_dict:set(key, 0, 0)  -- Healthy: reset failures, no TTL
+            ngx.log(ngx.WARN, "health check success for: ", ip, ":", port)
         else
             local failures = health_dict:get(key) or 0
             health_dict:set(key, failures + 1, 60)  -- Unhealthy: increment failures with TTL
+            ngx.log(ngx.WARN, "health check failed for: ", ip, ":", port, "failures: ", failures + 1)
         end
 
         ::continue::
@@ -75,14 +83,13 @@ end
 
 ngx.timer.every(1, health_check_timer)
 
-local function track_node_failure(ip, port)
+local function track_node_failure(ip, port, name)
     local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
     if not health_dict then
         return
     end
-    local key = ip .. ":" .. port
+    local key = generate_key(name, ip, port)
     health_dict:incr(key, 1, 0, 60)
-    local all_keys = health_dict:get_keys()
 end
 
 local function parse_key(key_str)
@@ -106,13 +113,13 @@ local master_nodes = {}
 
 
 
-local function is_node_healthy(ip, port)
+local function is_node_healthy(ip, port, name)
     local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
     if not health_dict then
         return true
     end
 
-    local key = ip .. ":" .. port
+    local key = generate_key(name, ip, port)
     local is_healthy = (health_dict:get(key) or 0) <= 3
     return is_healthy
 end
@@ -177,7 +184,7 @@ local function try_hosts_slots(self, serv_list)
     for i = 1, #serv_list do
         local ip = serv_list[i].ip
         local port = serv_list[i].port
-        local is_healthy = is_node_healthy(ip, port)
+        local is_healthy = is_node_healthy(ip, port, self.config.name)
         if not is_healthy then
             goto continue
         end
@@ -203,7 +210,7 @@ local function try_hosts_slots(self, serv_list)
                 break 
             end
             if err then
-                track_node_failure(ip, port)
+                track_node_failure(ip, port, self.config.name)
                 table_insert(errors, err)
             end
         end
@@ -337,7 +344,7 @@ function _M.refresh_slots(self)
     local current_nodes = {}
     local servers = slot_cache[self.config.name .. "serv_list"].serv_list
     for _, node in ipairs(servers) do
-        local key = node.ip .. ":" .. node.port
+        local key = generate_key(self.config.name, node.ip, node.port)
         current_nodes[key] = true
     end
     -- Cleanup stale nodes
@@ -424,7 +431,7 @@ local function pick_node(self, serv_list, slot, magic_radom_seed)
     local healthy_servers = {}
     for i, node in ipairs(serv_list) do
         -- first node here is master. If its unhealthy then we should return err
-        local is_healthy = is_node_healthy(node.ip, node.port)
+        local is_healthy = is_node_healthy(node.ip, node.port, self.config.name)
         if i == 1 and not is_healthy then
             return nil, nil, nil, err_unhealthy_master
         end
@@ -557,7 +564,7 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
                                   config.read_timeout or DEFAULT_READ_TIMEOUT)
         local ok, connerr = redis_client:connect(ip, port, self.config.connect_opts)
         if not ok then
-            track_node_failure(ip, port)
+            track_node_failure(ip, port, self.config.name)
         end
         if ok then
             local authok, autherr = check_auth(self, redis_client)
@@ -619,7 +626,7 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
                     return nil, "Cannot executing command, cluster status is failed!"
                 else
                     --There might be node fail, we should also refresh slot cache
-                    track_node_failure(ip, port)
+                    track_node_failure(ip, port, self.config.name)
                     self:refresh_slots()
                     return nil, err
                 end

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -1,4 +1,3 @@
-
 local redis = require "resty.redis"
 local resty_lock = require "resty.lock"
 local xmodem = require "resty.xmodem"

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -39,8 +39,6 @@ local function health_check_timer(premature)
     if not health_dict then return end
 
     local all_keys = health_dict:get_keys()
-    ngx.log(ngx.WARN, "Health check for keys: ", inspect(all_keys))
-
     for _, key in ipairs(all_keys) do
         local ip, port = string.match(key, "^(.-):(%d+)$")
         if not ip or not port then
@@ -62,17 +60,14 @@ local function health_check_timer(premature)
                 ok = false
                 err = "PING failed"
             end
-            ngx.log(ngx.WARN, "Health check for node ", key, ": ", res, " err: ", err)
             red:close()  -- Close connection after check
         end
         -- Update health status based on check
         if ok then
             health_dict:set(key, 0, 0)  -- Healthy: reset failures, no TTL
-            ngx.log(ngx.WARN, "Node ", key, " is healthy (failures=0)")
         else
             local failures = health_dict:get(key) or 0
             health_dict:set(key, failures + 1, 60)  -- Unhealthy: increment failures with TTL
-            ngx.log(ngx.WARN, "Node ", key, " is unhealthy (failures=", failures + 1, ")")
         end
 
         ::continue::
@@ -82,19 +77,13 @@ end
 ngx.timer.every(1, health_check_timer)
 
 local function track_node_failure(ip, port)
-    ngx.log(ngx.WARN, "track node failure for ip:", ip, " port:", port)
     local health_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
     if not health_dict then
         return
     end
-    ngx.log(ngx.WARN, "track node failure for ip: 2", ip, " port:", port)
     local key = ip .. ":" .. port
     health_dict:incr(key, 1, 0, 60)
-    -- if not newval then
-    --     health_dict:set(key, 1, 0, 60)
-    -- end
     local all_keys = health_dict:get_keys()
-    ngx.log(ngx.WARN, "Health check for keys after track node fail: ", inspect(all_keys))
 end
 
 local function parse_key(key_str)
@@ -126,10 +115,6 @@ local function is_node_healthy(ip, port)
 
     local key = ip .. ":" .. port
     local is_healthy = (health_dict:get(key) or 0) <= 3
-    if not is_healthy then
-        ngx.log(ngx.WARN, "node is unhealthy, ip:", ip, " port:", port)
-        ngx.log(ngx.WARN, "node failure count:", health_dict:get(key))
-    end
     return is_healthy
 end
 
@@ -303,7 +288,6 @@ end
 
 
 function _M.fetch_slots(self)
-    ngx.log(ngx.WARN, "CALLED FETCH SLOT")
     local serv_list = self.config.serv_list
     local serv_list_cached = slot_cache[self.config.name .. "serv_list"]
 
@@ -361,7 +345,6 @@ function _M.refresh_slots(self)
     local all_keys = health_dict:get_keys()
     for _, key in ipairs(all_keys) do
         if not current_nodes[key] then
-            ngx.log(ngx.WARN, "Cleaning up stale node: ", key)
             health_dict:delete(key)
         end
     end
@@ -375,7 +358,6 @@ end
 
 
 function _M.init_slots(self)
-    ngx.log(ngx.WARN, "CALLED INIT SLOTS")
     if slot_cache[self.config.name] then
         -- already initialized
         return true
@@ -421,7 +403,6 @@ end
 
 
 function _M.new(_, config)
-    ngx.log(ngx.WARN, "NEW CALLED")
     if not config.name then
         return nil, " redis cluster config name is empty"
     end
@@ -452,7 +433,6 @@ local function pick_node(self, serv_list, slot, magic_radom_seed)
             table_insert(healthy_servers, node)
         end
     end
-    ngx.log(ngx.WARN, "healthy servers: ", inspect(healthy_servers))
     if #healthy_servers == 0 then
         return nil, nil, nil, "No healthy nodes"
     end
@@ -540,9 +520,7 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
 
     key = tostring(key)
     local slot = redis_slot(key)
-    ngx.log(ngx.WARN, "HANDLE COMMAND CALLED WITH TARGET IP AND PORT", target_ip, " ", target_port)
     for k = 1, config.max_redirection or DEFAULT_MAX_REDIRECTION do
-        ngx.log(ngx.WARN, "handle retry attempts:" , k )
         local attempt_timeout = k == 1 and 100 or 800  -- 100ms first attempt, 800ms retry
         if k > 1 then
             ngx.log(ngx.WARN, "handle retry attempts:" .. k .. " for cmd:" .. cmd .. " key:" .. key)
@@ -574,13 +552,11 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
                 return nil, err
             end
         end
-        ngx.log(ngx.WARN, "handle command with ip and port", ip, " ", port)
         local redis_client = redis:new()
         redis_client:set_timeouts(attempt_timeout,
                                   config.send_timeout or DEFAULT_SEND_TIMEOUT,
                                   config.read_timeout or DEFAULT_READ_TIMEOUT)
         local ok, connerr = redis_client:connect(ip, port, self.config.connect_opts)
-        ngx.log(ngx.WARN, "okay and connerr", ok, " ", connerr)
         if not ok then
             track_node_failure(ip, port)
         end
@@ -614,7 +590,6 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
             else
                 res, err = redis_client[cmd](redis_client, key, ...)
             end
-            ngx.log(ngx.WARN, "err returned is ", err)
             if err then
                 if string.sub(err, 1, 5) == "MOVED" then
                     --ngx.log(ngx.NOTICE, "find MOVED signal, trigger retry for normal commands, cmd:" .. cmd .. " key:" .. key)
@@ -655,7 +630,6 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
                 return res, err
             end
         else
-            ngx.log(ngx.ERR, "I WAS HERE")
             --There might be node fail, we should also refresh slot cache
             self:refresh_slots()
             if k == config.max_redirection or k == DEFAULT_MAX_REDIRECTION then
@@ -664,7 +638,6 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
             end
         end
     end
-    ngx.log(ngx.WARN, "WE GOT A PROBLEM")
     return nil, "failed to execute command, reaches maximum redirection attempts"
 end
 

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -30,7 +30,7 @@ local DEFAULT_SEND_TIMEOUT = 1000
 local DEFAULT_READ_TIMEOUT = 1000
 local DEFAULT_HEALTH_DICT_NAME = "redis_cluster_health"
 local err_unhealthy_master = "master node is unhealthy"
-local inspect = require "inspect"
+
 local function generate_key(name, ip, port)
     return name .. ":" .. ip .. ":" .. port
 end
@@ -47,7 +47,6 @@ local function health_check_timer(premature)
     end
 
     local all_keys = health_dict:get_keys()
-    ngx.log(ngx.WARN, "health check keys: ", inspect(all_keys))
     for _, key in ipairs(all_keys) do
         local ip, port = string.match(key, "^[^:]+:([^:]+):(%d+)$")
         if not ip or not port then


### PR DESCRIPTION
The core idea behind these changes is to minimise APISIX CPU usage when a redis node is down by creating a healthcheck on failed node and if the node is still failing we can return early instead of sending request to redis and getting a timeout.

First request returns "timeout", this starts the health check and as health check fails the subsequent requests return "master node is unhealthy" instead of establishing communication to unhealthy node.
![Screenshot from 2025-04-25 11-45-39](https://github.com/user-attachments/assets/8b0026a4-1565-4588-bb39-c1298d894fa2)


The CPU usage of APISIX remains under 5% while redis node is under stress
![Screenshot from 2025-04-25 11-41-44](https://github.com/user-attachments/assets/14f7ac28-53b0-4a31-add5-308eef6163d8)
![Screenshot from 2025-04-25 11-41-52](https://github.com/user-attachments/assets/1346e340-49f5-4a6f-8339-1376f8ec4e64)
![Screenshot from 2025-04-25 11-44-09](https://github.com/user-attachments/assets/e91be891-54ac-4cc5-944b-ae3f93844e38)
![Screenshot from 2025-04-25 11-44-38](https://github.com/user-attachments/assets/10aa5a0c-aa14-4a93-83d4-7caeb7044086)


## How to test changes.
1. Checkout this commit in ee https://github.com/api7/api7-ee-3-gateway/pull/883
2. search for rediscluster.lua file in deps and replace the content with the one in this PR.
3. Run a redis cluster.
4. Add a route with limit count plugin cluster. Set sync_delay > 0. (To also test the feature PR in ee that uses local cache)
6. Send a request. 
7. Stress the master redis node where the key slot is.
8. Send request again(it will still be rate limited using local cache.)
9.  Use wrk to send the traffic. 
10. It should not cause any CPU spike in APISIX process..