### PR TITLE
fix: do not treat NOSCRIPT as node failure

### DIFF
--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -352,17 +352,19 @@ function _M.refresh_slots(self)
     self:fetch_slots()
     -- Cleanup health dict entries for removed nodes
     local unhealthy_nodes_dict = ngx.shared[DEFAULT_HEALTH_DICT_NAME]
-    local current_nodes = {}
-    local servers = slot_cache[self.config.name .. "serv_list"].serv_list
-    for _, node in ipairs(servers) do
-        local key = generate_key(self.config.name, node.ip, node.port)
-        current_nodes[key] = true
-    end
-    -- Cleanup stale nodes
-    local all_keys = unhealthy_nodes_dict:get_keys()
-    for _, key in ipairs(all_keys) do
-        if not current_nodes[key] then
-            unhealthy_nodes_dict:delete(key)
+    if unhealthy_nodes_dict then
+        local current_nodes = {}
+        local servers = slot_cache[self.config.name .. "serv_list"].serv_list
+        for _, node in ipairs(servers) do
+            local key = generate_key(self.config.name, node.ip, node.port)
+            current_nodes[key] = true
+        end
+        -- Cleanup stale nodes
+        local all_keys = unhealthy_nodes_dict:get_keys()
+        for _, key in ipairs(all_keys) do
+            if not current_nodes[key] then
+                unhealthy_nodes_dict:delete(key)
+            end
         end
     end
 
@@ -635,6 +637,8 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
 
                 elseif string.sub(err, 1, 11) == "CLUSTERDOWN" then
                     return nil, "Cannot executing command, cluster status is failed!"
+                elseif string.sub(err, 1, 8) == "NOSCRIPT" then
+                    return nil, err
                 else
                     --There might be node fail, we should also refresh slot cache
                     track_node_failure(ip, port, self.config.name)

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -929,4 +929,52 @@ GET /t
 ^.*failed to fetch slots: connection refused.*$
 --- timeout: 3
 --- no_error_log
+
+
+
+=== TEST 14: evalsha NOSCRIPT returns error without crash
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local config = {
+                            name = "testCluster",
+                            serv_list = {
+                                            { ip = "127.0.0.1", port = 7000 },
+                                            { ip = "127.0.0.1", port = 7001 },
+                                            { ip = "127.0.0.1", port = 7002 },
+                                            { ip = "127.0.0.1", port = 7003 },
+                                            { ip = "127.0.0.1", port = 7004 },
+                                            { ip = "127.0.0.1", port = 7005 },
+                                            { ip = "127.0.0.1", port = 7006 }
+                                        },
+                            keepalive_timeout = 60000,
+                            keepalive_cons = 1000,
+                            connect_timeout = 1000,
+                            read_timeout = 1000,
+                            send_timeout = 1000,
+                            max_redirection = 5
+            }
+            local redis = require "resty.rediscluster"
+            local red, err = redis:new(config)
+            if err then
+                ngx.say("failed to create: ", err)
+                return
+            end
+
+            -- Use a fake SHA that does not exist on any node
+            local res, err = red:evalsha("0000000000000000000000000000000000000000", 1, "noscript_test_key")
+            if err then
+                ngx.say("evalsha error: ", err)
+            else
+                ngx.say("evalsha result: ", tostring(res))
+            end
+        ';
+    }
+--- request
+GET /t
+--- response_body_like
+^evalsha error: NOSCRIPT.*$
+--- no_error_log
+[error]
 [alert]


### PR DESCRIPTION
The catch-all `else` branch in `handle_command_with_retry()` treats all unrecognized Redis errors as node failures, calling `track_node_failure()` + `refresh_slots()`. This is wrong for `NOSCRIPT` — it's a normal application-level error from `evalsha` when the script cache is empty, not a sign of node failure.

This causes a crash when callers use `evalsha` with Redis Cluster: the first `evalsha` after a script cache flush returns `NOSCRIPT`, which triggers `refresh_slots()`, which accesses `ngx.shared["redis_cluster_health"]` without a nil guard and crashes if the shared dict is not configured.

Changes:
- Add `NOSCRIPT` prefix check before the catch-all error handler, returning the error directly without `track_node_failure`/`refresh_slots`
- Add nil guard for `unhealthy_nodes_dict` in `refresh_slots()` to prevent crash when the health shared dict is not configured
- Add test case for `evalsha` NOSCRIPT handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for script-not-found errors in command retry logic.
  * Fixed potential failures when health monitoring state is unavailable, improving cluster reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/lua-resty-redis-cluster/pull/17)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->